### PR TITLE
Fixed a bug with image popups metadata text

### DIFF
--- a/assets/proc.js
+++ b/assets/proc.js
@@ -448,7 +448,7 @@ function crunchMetadata(url) {
     if (!('metadata' in rawData)) {
         return {};
     }
-    initialData = rawData.metadata;
+    initialData = structuredClone(rawData.metadata);
     var index = 0;
     for (var part of url.substring(0, url.indexOf('.')).split('/')) {
         var axis = rawData.axes[index++];


### PR DESCRIPTION
When generating the text for the popup the metadata is modified destructively through the reference/variable initialData. The prompt replaces that happen in crunchParamHook replace the original metadata.
https://github.com/mcmonkeyprojects/sd-infinity-grid-generator-script/blob/6e788bb64ddf45a87615d89248a20a376f35942f/assets/a1111webui.js#L66-L68 
I cloned the metadata instead so the original is preserved.

If the issue wasn't clear from my description here's a video.



https://user-images.githubusercontent.com/3950620/226901170-5288e121-fcec-41f1-a542-6bf0da44278f.mp4


