### PR TITLE
Add word-break: break-all; to styles.css

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -30,6 +30,7 @@ table tr td,
 table tr th {
     vertical-align: top;
     border: 1px solid black;
+    word-break: break-all;
 }
 th {
     position: sticky;
@@ -76,6 +77,7 @@ th {
     left: 0px;
     background-color: #202020;
     background-clip: padding-box;
+    word-break: break-all;
 }
 .superaxis_second {
     background-color: #303030;


### PR DESCRIPTION
Sometimes labels can be long especially with prompt replace axis or model axis, and this makes grids very sparse or requires horizontal scrolling.
This commit makes such situation better.