### PR TITLE
Fix for #85: 'Auto-scale images to viewport' to should exclude hidden items

### DIFF
--- a/assets/proc.js
+++ b/assets/proc.js
@@ -405,17 +405,22 @@ function getCurrentSelectedAxis(axisPrefix) {
     return id.substring(index + 1);
 }
 
+function getShownItemsOfAxis(axis)
+{
+    return axis.values.filter(item => canShowVal(axis.id, item.key));
+}
+
 function getWantedScaling() {
     if (!document.getElementById('autoScaleImages').checked) {
         return 0;
     }
     var x = getCurrentSelectedAxis('x');
     var xAxis = getAxisById(x);
-    var count = xAxis.values.length;
+    var count = getShownItemsOfAxis(xAxis).length;
     var x2 = getCurrentSelectedAxis('x2');
     if (x2 != 'none') {
         var x2Axis = getAxisById(x2);
-        count *= x2Axis.values.length;
+        count *= getShownItemsOfAxis(x2Axis).length;
     }
     return (90 / count);
 }


### PR DESCRIPTION
You can use the advanced options to hide values on an axis, but the code was calculating the total width assuming that all items will be visible.

So if you had 10 elements on an axis and only 5 were to be shown, it would still scale stuff down to fit all 10 items, making the images too small.