### PR TITLE
PR for #87: Add support for including other files in the grid file

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,3 +2,5 @@ import launch
 
 if not launch.is_installed("yaml"):
     launch.run_pip("install pyyaml", "pyyaml for Infinity Grid Script")
+if not launch.is_installed("pyyaml-include"):
+    launch.run_pip("install pyyaml-include", "pyyaml-include for Infinity Grid Script")


### PR DESCRIPTION
- Updated install.py to install pyyaml-include
- gridgencore.py defines a custom subclass of yaml.SafeLoader to patch with YamlIncludeConstructor
- run_grid_gen takes 'allow_includes' argument. When it's true (the default), it uses the patched SafeLoader subclass to load the yaml instead of yaml.safe_load.