### PR TITLE
Added styles-user.css to assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 assets/*.yml
+assets/styles-user.css
 __pycache__/
 assets/images/**/*.png
 assets/images/**/*.jpg

--- a/assets/page.html
+++ b/assets/page.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="bootstrap.min.css" media="screen">
     <link rel="stylesheet" href="styles.css?vary={VERSION}" media="screen">
+    <link rel="stylesheet" href="styles-user.css?vary={VERSION}" media="screen">
     <title>{TITLE}</title>
     <meta name="description" content="{CLEAN_DESCRIPTION}" />
     <script src="jquery.min.js"></script>

--- a/assets/styles-user.css
+++ b/assets/styles-user.css
@@ -1,3 +1,3 @@
 /*
- Add your own CSS rules to this file instead of modifying styles.css
- */
+ Add your own CSS rules to this file (instead of modifying styles.css)
+*/

--- a/assets/styles-user.css
+++ b/assets/styles-user.css
@@ -1,0 +1,3 @@
+/*
+ Add your own CSS rules to this file instead of modifying styles.css
+ */

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,3 +1,5 @@
+@import url('styles-user.css');
+
 .sel_table tr td {
     border: 1px solid black;
     padding-right: 16px;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,4 +1,6 @@
-@import url('styles-user.css');
+/*
+ If you want to customize your stylesheet, please edit 'styles-user.css' instead of this.
+*/
 
 .sel_table tr td {
     border: 1px solid black;

--- a/gridgencore.py
+++ b/gridgencore.py
@@ -639,7 +639,7 @@ class WebDataBuilder():
             f.write("rawData = " + json)
         with open(path + "/config.yml", 'w', encoding="utf-8") as f:
             yaml.dump(yaml_content, f, sort_keys=False, default_flow_style=False, width=1000)
-        for f in ["bootstrap.min.css", "jsgif.js", "bootstrap.bundle.min.js", "proc.js", "jquery.min.js", "styles.css", "placeholder.png"] + EXTRA_ASSETS:
+        for f in ["bootstrap.min.css", "jsgif.js", "bootstrap.bundle.min.js", "proc.js", "jquery.min.js", "styles.css", "styles-user.css", "placeholder.png"] + EXTRA_ASSETS:
             shutil.copyfile(ASSET_DIR + "/" + f, path + "/" + f)
         html = WebDataBuilder.build_html(grid)
         with open(path + "/index.html", 'w', encoding="utf-8") as f:


### PR DESCRIPTION
The user can add rules to this file instead of modifying styles.css so updating the extension doesn't overwrite their customizations.

- Added assets/styles-user.css containing just a comment explaining it
- Added it to .gitignore
- Updated gridgencore.py to copy styles-user.css

For #104.