### PR TITLE
The img/gif output is shown in a modal popup

### DIFF
--- a/assets/page.html
+++ b/assets/page.html
@@ -50,9 +50,8 @@
                 </div>
             </div>
             <div id="save_image_helper" class="save_image_area">
-                <button onclick="makeImage()">Save Image Of Current View</button> <select title="Image Type" id="makeimage_type"><option>jpeg</option><option>png</option></select>
-                <button onclick="makeGif()">Create Axis GIF Animation</button> <select title="Axis" id="makegif_axis"><option value="x-axis">X Axis</option></select> <select title="GIF Size" id="makegif_size"><option>1x</option><option>0.75x</option><option selected>0.5x</option><option>0.25x</option></select> <select title="GIF Speed" id="makegif_speed"><option>1/s</option><option>2/s</option><option>3/s</option><option selected>4/s</option><option>5/s</option><option>10/s</option></select>
-                <div id="save_image_info" style="display: none;">Here's your image! To share it, just use right click -> Copy image or Save Image As</div>
+                <button onclick="makeImage()" data-bs-toggle="modal" data-bs-target="#save_image_output_modal">Save Image Of Current View</button> <select title="Image Type" id="makeimage_type"><option>jpeg</option><option>png</option></select>
+                <button onclick="makeGif()" data-bs-toggle="modal" data-bs-target="#save_image_output_modal">Create Axis GIF Animation</button> <select title="Axis" id="makegif_axis"><option value="x-axis">X Axis</option></select> <select title="GIF Size" id="makegif_size"><option>1x</option><option>0.75x</option><option selected>0.5x</option><option>0.25x</option></select> <select title="GIF Speed" id="makegif_speed"><option>1/s</option><option>2/s</option><option>3/s</option><option selected>4/s</option><option>5/s</option><option>10/s</option></select>
             </div>
         </div>
         <div class="image_table_box">
@@ -61,6 +60,20 @@
         </div>
     </div>
     <div class="modal modal-fullscreen popup_modal_background" id="image_info_modal"></div>
+    <div class="modal" tabindex="-1" id="save_image_output_modal">
+        <div class="modal-dialog modal-xl">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Here's your image!</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>To share it, just use right click -> Copy image or Save Image As.</p>
+                    <div id="save_image_output" class="save_image_output"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <br><div style="width:256px;height:512px;"></div> <!-- Spacer to reduce screen-jumping if images load while you're scrolled down -->
     <footer>
         <center>

--- a/assets/proc.js
+++ b/assets/proc.js
@@ -656,6 +656,10 @@ function toggleLabelSticky() {
     }
 }
 
+function removeGeneratedImages() {
+    document.getElementById('save_image_output').innerHTML = "";
+}
+
 function makeImage(minRow = 0, doClear = true) {
     // Preprocess data
     var imageTable = document.getElementById('image_table');
@@ -688,16 +692,11 @@ function makeImage(minRow = 0, doClear = true) {
         rowData.push({ row, images, real_images, height, label, y });
     }
     console.log(`Will create image at ${widest_width * columns} x ${total_height} pixels`);
-    var holder = document.getElementById('save_image_helper');
+    var holder = document.getElementById('save_image_output');
     if (doClear) {
-        for (var oldImage of holder.getElementsByTagName('img')) {
-            oldImage.remove();
-        }
-        for (var oldImage of holder.getElementsByTagName('canvas')) {
-            oldImage.remove();
-        }
+        removeGeneratedImages();
     }
-    document.getElementById('save_image_info').style.display = 'block';
+    
     // Temporary canvas to measure what padding we need
     var canvas = new OffscreenCanvas(256, 256);
     var ctx = canvas.getContext('2d');
@@ -827,7 +826,8 @@ function makeImage(minRow = 0, doClear = true) {
     try {
         var data = canvas.toDataURL(`image/${imageType}`);
         canvas.remove();
-        var img = new Image(256, 256);
+        var img = new Image();
+        img.className = "generated";
         img.src = data;
         holder.appendChild(img);
     }
@@ -839,11 +839,8 @@ function makeImage(minRow = 0, doClear = true) {
 }
 
 function makeGif() {
-    let holder = document.getElementById('save_image_helper');
-    document.getElementById('save_image_info').style.display = 'block';
-    for (var oldImage of holder.getElementsByTagName('img')) {
-        oldImage.remove();
-    }
+    let holder = document.getElementById('save_image_output');
+    removeGeneratedImages();
     let axisId = document.getElementById('makegif_axis').value;
     if (axisId == 'x-axis') {
         axisId = getCurrentSelectedAxis('x');
@@ -893,6 +890,7 @@ function makeGif() {
                 let binary_gif = encoder.stream().getData();
                 let data_url = 'data:image/gif;base64,' + encode64(binary_gif);
                 let animatedImage = document.createElement('img');
+                animatedImage.className = "generated";
                 animatedImage.src = data_url;
                 image1.remove();
                 image2.remove();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -132,4 +132,13 @@ table tr td:first-child {
 }
 .image_table {
     margin: auto;
+} 
+
+.save_image_output {
+    text-align: center;
+}
+
+.save_image_output img.generated {
+    max-width: 100%;
+    max-height: 70vh;
 }


### PR DESCRIPTION
- page.html: Added bootstrap modal placeholder. Clicking either button makes modal show, which has the #save_image_output container
- proc.js: Adds/removes content in the #save_image_output div, and adds the 'generated' class name to output images
- styles.css: Constrains generated images to be at most the width of the modal and 70% of the window height.

For #106.