### PR TITLE
Added key “webp” to enum “grid.format” in grid definition schema

### DIFF
--- a/assets/grid.schema.json
+++ b/assets/grid.schema.json
@@ -123,7 +123,7 @@
                 },
                 "format": {
                     "type": "string",
-                    "enum": ["png", "jpg"]
+                    "enum": ["png", "jpg", "webp"]
                 }
             },
             "required": [


### PR DESCRIPTION
Just a small addition to the schema to make my local validation stop nagging me about it.

![image](https://github.com/mcmonkeyprojects/sd-infinity-grid-generator-script/assets/6216144/dccebef4-a3bd-4f48-98b7-4e0b6bc45d2f)

The WebP format is perfectly supported by both [the image saving routine of Automatic1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/a30b19dd5536f463222e484aef2daf466b49ee85/modules/images.py#L591-L597) and [the browser that displays the generated megagrid](https://caniuse.com/webp).